### PR TITLE
Use HTTPS for Git Clone

### DIFF
--- a/bin/installer.sh
+++ b/bin/installer.sh
@@ -9,7 +9,7 @@ printf "Step 1: clonning the repository to ${_YELLOW}$HOME/.phpqa/bin/phpqa.sh${
 if [ -d "$HOME/.phpqa" ]; then
     rm -rf $HOME/.phpqa;
 fi
-git clone git@github.com:herdphp/docker-phpqa.git $HOME/.phpqa;
+git clone https://github.com/herdphp/docker-phpqa.git $HOME/.phpqa;
 
 printf "Step 2: linking ${_YELLOW}phpqa.sh${_NC} to ${_YELLOW}/usr/local/bin/phpqa${_NC} ...\n";
 if [ -L "/usr/local/bin/phpqa" ] ; then


### PR DESCRIPTION
I tried the installer inside a fresh VM. I couldn't figure out why the installer didn't install anything until I looked at the script . It was using SSH for the git clone. I didn't have my SSH keys in the VM so it failed. This patch switches the git clone to HTTPS so the clone won't fail for those working in a clean environment.